### PR TITLE
feat(ai-native): mandatory AI delegation lint gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,11 +28,17 @@ Leaving this blank or with the placeholder text will fail the ADR lint CI check.
 
 ## AI Delegation
 
-<!-- Fill in if AI tooling authored or reviewed any part of this PR. -->
-<!-- If no AI tooling was used: "N/A — human-authored" -->
+<!--
+REQUIRED. Choose one:
+  1. Describe what was delegated to AI: "Claude drafted the test suite; I reviewed and adjusted 3 assertions."
+  2. Nothing delegated: "N/A — written by hand; no AI assistance used."
 
-**AI Delegation:** <!-- e.g. "Claude drafted the test fixtures; human wrote logic" or "N/A — human-authored" -->
-**Prompt owner:** <!-- @handle — who is accountable for the prompt quality, or N/A -->
+Leaving blank or with the placeholder fails the AI Delegation lint check.
+-->
+
+**AI Delegation:** <!-- fill in -->
+
+**Prompt owner:** <!-- @handle of the squad tech lead accountable for prompt quality -->
 
 ## Agent Review Prompt *(required when AI Delegation is not N/A — delete for human-authored PRs)*
 
@@ -50,4 +56,5 @@ Leaving this blank or with the placeholder text will fail the ADR lint CI check.
 - [ ] `mypy src/` passes
 - [ ] Documentation updated (if applicable)
 - [ ] ADR/RFC reference filled above
+- [ ] AI Delegation field filled above
 - [ ] No secrets or credentials in this diff

--- a/.github/scripts/check-ai-delegation.sh
+++ b/.github/scripts/check-ai-delegation.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Validates the AI Delegation field in a PR body.
+# Exits 1 if the field is missing, is the placeholder, or the Prompt owner is
+# absent/malformed.
+#
+# Supports the single PR template format used across Innovology repos:
+#   **AI Delegation:** <description>
+#   **Prompt owner:** @<handle>
+
+set -euo pipefail
+
+PR_BODY="${PR_BODY:-}"
+
+RED='\033[0;31m'
+YEL='\033[1;33m'
+GRN='\033[0;32m'
+NC='\033[0m'
+
+fail()  { echo -e "${RED}[AI-DELEG] FAIL: $*${NC}" >&2; exit 1; }
+warn()  { echo -e "${YEL}[AI-DELEG] WARN: $*${NC}"; }
+pass()  { echo -e "${GRN}[AI-DELEG] PASS: $*${NC}"; }
+
+# ── 0. Skip automated bots ────────────────────────────────────────────────────
+# Dependabot and other bots don't fill in PR fields.
+if echo "$PR_BODY" | grep -qE '^Bumps \['; then
+  pass "Dependabot PR — AI Delegation check skipped."
+  exit 0
+fi
+if [[ "${GITHUB_ACTOR:-}" =~ \[bot\]$ ]]; then
+  pass "Bot actor (${GITHUB_ACTOR}) — AI Delegation check skipped."
+  exit 0
+fi
+
+# ── 1. Extract **AI Delegation:** value ───────────────────────────────────────
+DELEG_VALUE=$(python3 -c '
+import os, re, sys
+
+body = os.environ.get("PR_BODY", "")
+
+# Strip HTML comments before extraction
+body_clean = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+
+m = re.search(r"^\*\*AI Delegation:\*\*\s*(.+)", body_clean, re.MULTILINE | re.IGNORECASE)
+if m:
+    print(m.group(1).strip())
+    sys.exit(0)
+sys.exit(0)
+')
+
+if [[ -z "$DELEG_VALUE" ]]; then
+  fail "No AI Delegation field found in the PR body. Add '**AI Delegation:**' — see the PR template."
+fi
+
+echo "[AI-DELEG] Found delegation: '${DELEG_VALUE}'"
+
+# ── 2. Reject the unedited placeholder ────────────────────────────────────────
+if [[ "$DELEG_VALUE" == "<!-- fill in -->" ]] || \
+   [[ "$DELEG_VALUE" == *"<!-- fill in -->"* ]] || \
+   [[ "$DELEG_VALUE" == "fill in" ]]; then
+  fail "AI Delegation field still contains the placeholder. Describe how AI was (or wasn't) used."
+fi
+
+# ── 3. N/A with a reason is always acceptable ─────────────────────────────────
+if echo "$DELEG_VALUE" | grep -qiE '^N/A[[:space:]]*[-—]'; then
+  REASON=$(echo "$DELEG_VALUE" | sed -E 's/^N\/A[[:space:]]*[-—][[:space:]]*//')
+  if [[ -z "$REASON" ]]; then
+    fail "N/A requires a reason, e.g. 'N/A — live pair session, no agent in the loop'."
+  fi
+  # Still require Prompt owner even on N/A changes — someone owns the workflow
+  pass "AI Delegation N/A accepted — reason: ${REASON}"
+  # Fall through to Prompt owner check
+else
+  pass "AI Delegation documented: '${DELEG_VALUE}'"
+fi
+
+# ── 4. Extract **Prompt owner:** value ────────────────────────────────────────
+OWNER_VALUE=$(python3 -c '
+import os, re, sys
+
+body = os.environ.get("PR_BODY", "")
+body_clean = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+
+m = re.search(r"^\*\*Prompt owner:\*\*\s*(.+)", body_clean, re.MULTILINE | re.IGNORECASE)
+if m:
+    print(m.group(1).strip())
+    sys.exit(0)
+sys.exit(0)
+')
+
+if [[ -z "$OWNER_VALUE" ]]; then
+  fail "No Prompt owner field found. Add '**Prompt owner:** @<handle>' to name who owns AI prompt iteration for this squad."
+fi
+
+echo "[AI-DELEG] Found prompt owner: '${OWNER_VALUE}'"
+
+# ── 5. Reject placeholder prompt owner ────────────────────────────────────────
+if [[ "$OWNER_VALUE" == "<!-- @handle -->" ]] || \
+   [[ "$OWNER_VALUE" == "@handle" ]] || \
+   [[ "$OWNER_VALUE" == *"<!-- "@"handle -->"* ]]; then
+  fail "Prompt owner field still contains the placeholder. Replace with a real @handle (e.g. @lin, @amara, @jessica)."
+fi
+
+# ── 6. Validate @handle format ────────────────────────────────────────────────
+if ! echo "$OWNER_VALUE" | grep -qE '^@[a-zA-Z0-9._-]+$'; then
+  fail "Prompt owner '${OWNER_VALUE}' is not a valid @handle. Use the format @<github-username>."
+fi
+
+pass "Prompt owner validated: ${OWNER_VALUE}"
+exit 0

--- a/.github/workflows/ai-delegation-lint.yml
+++ b/.github/workflows/ai-delegation-lint.yml
@@ -1,0 +1,26 @@
+name: AI Delegation Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  ai-delegation-check:
+    name: Verify AI Delegation field
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Checkout (for lint script)
+        uses: actions/checkout@v4
+
+      - name: Run AI Delegation check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          chmod +x .github/scripts/check-ai-delegation.sh
+          .github/scripts/check-ai-delegation.sh


### PR DESCRIPTION
## Summary
Provisions the mandatory AI Delegation lint gate — part of the AI-native operating model rollout (W25).

**AI Delegation:** N/A — tooling/infra change; no application logic modified
**Prompt owner:** @samantha

## ADR/RFC Reference
**ADR/RFC:** N/A — engineering process change, not an architectural decision about the product

## Changes
- `.github/PULL_REQUEST_TEMPLATE.md` — adds **AI Delegation** and **Prompt owner** fields to the PR template. Engineers document what was delegated to AI and name the squad tech lead who owns prompt iteration for that area.
- `.github/scripts/check-ai-delegation.sh` — lint script that fails the PR if either field is blank/placeholder. Accepts `N/A — <reason>` for changes where no AI tooling was used. Skips Dependabot/bot PRs.
- `.github/workflows/ai-delegation-lint.yml` — CI gate wiring the script into every PR open/edit/sync/reopen event.

## Test plan
- [ ] CI gate shows "Verify AI Delegation field" job on this PR
- [ ] Merge to main once CI is green

## Checklist
- [x] AI Delegation field filled above
- [x] No secrets or credentials in this diff