### PR TITLE
style: apply ruff format to 4 files introduced in 3947e1c

### DIFF
--- a/src/cortiva/core/fabric.py
+++ b/src/cortiva/core/fabric.py
@@ -4542,7 +4542,8 @@ class Fabric:
             from cortiva.core import commitments as _cm
 
             own_open = [
-                c for c in _cm.load(agent.directory)
+                c
+                for c in _cm.load(agent.directory)
                 if getattr(c, "status", "open") not in ("delivered", "withdrawn")
             ]
         except Exception:
@@ -4907,9 +4908,7 @@ class Fabric:
             "left unmerged is finished work you haven't shipped.\n",
         ]
         for d in opens[:15]:
-            seen = (
-                f" · seen {d.get('count')}×" if int(d.get("count", 1)) > 1 else ""
-            )
+            seen = f" · seen {d.get('count')}×" if int(d.get("count", 1)) > 1 else ""
             lines.append(f"- **{d.get('ref', '')}** — {d.get('subject', '')}{seen}")
         if len(opens) > 15:
             lines.append(
@@ -5538,14 +5537,19 @@ class Fabric:
             if count >= self._OUTBOX_MAX_SENDS:
                 logger.info(
                     "Suppressed re-send for %s to %s (%d already sent, awaiting reply): %s",
-                    agent.id, to, count, spec.get("subject"),
+                    agent.id,
+                    to,
+                    count,
+                    spec.get("subject"),
                 )
                 self._emit("email.suppressed", agent_id=agent.id, to=to, reason="max_sends")
                 return
             if last and (now - last).total_seconds() < self._OUTBOX_DEBOUNCE_S:
                 logger.info(
                     "Suppressed re-send for %s to %s (debounce, awaiting reply): %s",
-                    agent.id, to, spec.get("subject"),
+                    agent.id,
+                    to,
+                    spec.get("subject"),
                 )
                 self._emit("email.suppressed", agent_id=agent.id, to=to, reason="debounce")
                 return
@@ -5828,12 +5832,13 @@ class Fabric:
             # This agent reports to the founder (i.e. the CEO).
             if founder:
                 self._queue_outbound_email(
-                    agent, {"to": founder, "subject": subject, "body": body},
+                    agent,
+                    {"to": founder, "subject": subject, "body": body},
                 )
             else:
                 logger.warning(
-                    "Escalation for %s reports to the founder but no founder "
-                    "contact is configured", agent.id,
+                    "Escalation for %s reports to the founder but no founder contact is configured",
+                    agent.id,
                 )
         elif mgr_email:
             self._queue_outbound_email(
@@ -5847,7 +5852,8 @@ class Fabric:
             logger.warning(
                 "Escalation for %s could not be routed to a manager (mgr_id=%r); "
                 "not escalating to the founder — check the org directory push.",
-                agent.id, mgr_id,
+                agent.id,
+                mgr_id,
             )
 
     # ------------------------------------------------------------------

--- a/tests/test_calculated_action.py
+++ b/tests/test_calculated_action.py
@@ -55,7 +55,9 @@ def test_no_history_no_brake():
 def test_warm_thread_says_hold():
     agent = _agent()
     recent = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
-    _write_ledger(agent, {"k": {"to": "maren@x", "subject": "SRE brief", "count": 1, "last": recent}})
+    _write_ledger(
+        agent, {"k": {"to": "maren@x", "subject": "SRE brief", "count": 1, "last": recent}}
+    )
     out = _brake(_fab(), agent)
     assert "HOLD" in out
     assert "SRE brief" in out
@@ -66,7 +68,9 @@ def test_warm_thread_says_hold():
 def test_capped_thread_says_stop_and_escalate():
     agent = _agent()
     old = (datetime.now(UTC) - timedelta(hours=50)).isoformat()
-    _write_ledger(agent, {"k": {"to": "maren@x", "subject": "URGENT data", "count": 3, "last": old}})
+    _write_ledger(
+        agent, {"k": {"to": "maren@x", "subject": "URGENT data", "count": 3, "last": old}}
+    )
     out = _brake(_fab(), agent)
     assert "STOP" in out
     assert "escalate" in out.lower()
@@ -99,7 +103,15 @@ def test_reply_decrements_not_wipes():
     """A reply must NOT reset the cap to zero — it allows one more, no more."""
     agent = _agent()
     _write_ledger(
-        agent, {"maua@x|brief": {"to": "maren@x", "subject": "brief", "count": 3, "last": "2026-01-01T00:00:00+00:00"}}
+        agent,
+        {
+            "maua@x|brief": {
+                "to": "maren@x",
+                "subject": "brief",
+                "count": 3,
+                "last": "2026-01-01T00:00:00+00:00",
+            }
+        },
     )
     fab = SimpleNamespace(
         _load_outbox_ledger=lambda a: Fabric._load_outbox_ledger(SimpleNamespace(), a),

--- a/tests/test_escalation_routing.py
+++ b/tests/test_escalation_routing.py
@@ -1,5 +1,6 @@
 """Escalation routes up the management chain, and outbound is throttled so an
 unanswered ask can't become a message storm."""
+
 from __future__ import annotations
 
 import json
@@ -30,7 +31,11 @@ def test_resolve_manager_cross_node(tmp_path):
                 "directory": [
                     {"id": "amara", "reports_to": "cto"},
                     {"id": "cto", "email": "samantha@workforce.innovology.io", "reports_to": "ceo"},
-                    {"id": "ceo", "email": "maren@workforce.innovology.io", "reports_to": "human-founder"},
+                    {
+                        "id": "ceo",
+                        "email": "maren@workforce.innovology.io",
+                        "reports_to": "human-founder",
+                    },
                 ]
             }
         ),
@@ -58,8 +63,12 @@ def test_outbound_rapid_resends_are_suppressed(tmp_path):
 def test_distinct_threads_not_suppressed(tmp_path):
     f = _fab()
     agent = SimpleNamespace(id="amara", directory=tmp_path)
-    f._queue_outbound_email(agent, {"to": "simone@workforce.innovology.io", "subject": "A", "body": "x"})
-    f._queue_outbound_email(agent, {"to": "simone@workforce.innovology.io", "subject": "B", "body": "x"})
+    f._queue_outbound_email(
+        agent, {"to": "simone@workforce.innovology.io", "subject": "A", "body": "x"}
+    )
+    f._queue_outbound_email(
+        agent, {"to": "simone@workforce.innovology.io", "subject": "B", "body": "x"}
+    )
     sent = list((tmp_path / "outbox" / "email").glob("*.json"))
     assert len(sent) == 2  # different subjects are different threads
 
@@ -67,9 +76,13 @@ def test_distinct_threads_not_suppressed(tmp_path):
 def test_reply_clears_throttle(tmp_path):
     f = _fab()
     agent = SimpleNamespace(id="amara", directory=tmp_path)
-    f._queue_outbound_email(agent, {"to": "simone@workforce.innovology.io", "subject": "help", "body": "x"})
+    f._queue_outbound_email(
+        agent, {"to": "simone@workforce.innovology.io", "subject": "help", "body": "x"}
+    )
     # A reply from the recipient resets the thread so the conversation continues.
     f._clear_awaiting_for_senders(agent, {"simone@workforce.innovology.io"})
-    f._queue_outbound_email(agent, {"to": "simone@workforce.innovology.io", "subject": "help", "body": "x"})
+    f._queue_outbound_email(
+        agent, {"to": "simone@workforce.innovology.io", "subject": "help", "body": "x"}
+    )
     sent = list((tmp_path / "outbox" / "email").glob("*.json"))
     assert len(sent) == 2

--- a/tests/test_github_feedback.py
+++ b/tests/test_github_feedback.py
@@ -58,14 +58,23 @@ def test_same_thread_folds_and_counts_no_duplicates():
 def test_merge_notification_resolves_the_thread():
     _agent, rec, opn = _shim()
     rec([_gh("[Innovology/repo] adr-lint (PR #129)", "approved")])
-    rec([_gh("Re: [Innovology/repo] adr-lint (PR #129)", "samantha merged this pull request into main.")])
+    rec(
+        [
+            _gh(
+                "Re: [Innovology/repo] adr-lint (PR #129)",
+                "samantha merged this pull request into main.",
+            )
+        ]
+    )
     assert opn() == []
 
 
 def test_close_notification_resolves_the_thread():
     _agent, rec, opn = _shim()
     rec([_gh("[Innovology/repo] silent failure (Issue #102)", "reported")])
-    rec([_gh("Re: [Innovology/repo] silent failure (Issue #102)", "alex closed this as completed.")])
+    rec(
+        [_gh("Re: [Innovology/repo] silent failure (Issue #102)", "alex closed this as completed.")]
+    )
     assert opn() == []
 
 


### PR DESCRIPTION
## Summary

Fixes the Cortiva main CI Lint failure introduced by commit `3947e1c` (2026-06-28).

`ruff format --check .` reports 4 files would be reformatted — this PR applies the format. Zero logic change.

## Acceptance Criteria

- [ ] CI Lint job passes on this PR
- [ ] `ruff format --check .` exits 0 on the resulting main

## ADR/RFC Reference

**ADR/RFC:** N/A — format-only fix, no architectural decision

## Changes

- `src/cortiva/core/fabric.py` — ruff format applied
- `tests/test_calculated_action.py` — ruff format applied
- `tests/test_escalation_routing.py` — ruff format applied
- `tests/test_github_feedback.py` — ruff format applied

## Test plan

- [ ] CI Lint passes (ruff check + ruff format --check)
- [ ] CI tests unchanged (format-only diff)

## AI Delegation

**AI Delegation:** N/A — mechanical format application  
**Prompt owner:** @lin

## Checklist

- [x] Tests added or updated — N/A
- [x] Acceptance Criteria above are specific and testable
- [x] ADR/RFC reference filled
- [x] No secrets or credentials in this diff