### PR TITLE
style: ruff format agent_tools.py — unblock main CI

### DIFF
--- a/src/cortiva/core/agent_tools.py
+++ b/src/cortiva/core/agent_tools.py
@@ -428,8 +428,7 @@ ISSUE_STANDING_ORDER_TOOL: dict[str, Any] = {
                 "scope_value": {
                     "type": "string",
                     "description": (
-                        "The product slug or repo path. Leave empty for "
-                        "org-wide orders."
+                        "The product slug or repo path. Leave empty for org-wide orders."
                     ),
                 },
             },


### PR DESCRIPTION
## Summary

Unblocks cortiva main CI lint gate, red since commit \`94aa054\` (2026-07-01, @alexrbrowne).

**Root cause:** \`ISSUE_STANDING_ORDER_TOOL\` in \`src/cortiva/core/agent_tools.py\` had a two-line string description that ruff format collapses to one line. \`ruff format --check\` exits 1 on this file, blocking all PRs that depend on a green baseline.

**Fix:** Run \`ruff format\` — joins the split string. 1 file reformatted, zero logic change.

```diff
-                        "The product slug or repo path. Leave empty for "
-                        "org-wide orders."
+                        "The product slug or repo path. Leave empty for org-wide orders."
```

Verified locally: \`ruff format --check .\` now exits 0 (194 files already formatted).

## ADR/RFC Reference

**ADR/RFC:** N/A — format-only, no architectural decision required

## AI Delegation

**AI Delegation:** CPO (cpo-innovology) applied ruff format and verified format-only scope.
**Prompt owner:** @amara-innovology

## Agent Review Prompt

**Change summary:** Single ruff format fix to agent_tools.py — two-line string description joined to one line. Zero logic impact.
**Risks:** None — ruff format is deterministic and idempotent; this is exactly what \`ruff format .\` produces.
**Human review focus:** Confirm the diff is only the one-line string join shown above and no other changes are present.

## Acceptance Criteria

- [x] \`ruff format --check .\` exits 0 after this PR merges
- [x] No test files touched
- [x] No logic files changed beyond whitespace

@amara-innovology @alexrbrowne — please review and merge. CI should go green on push. This is blocking all open PRs in cortiva (#81, #91, #92, #98) from getting a clean baseline.