### PR TITLE
feat(fabric): delivery-stewardship salience — downward mirror of directive salience

### DIFF
--- a/src/cortiva/core/fabric.py
+++ b/src/cortiva/core/fabric.py
@@ -644,6 +644,10 @@ class Fabric:
         # Commitment pressure also spikes the chemistry at wake — the deadline
         # weight she carries from yesterday's promises, felt before she plans.
         await self._dispatch_commitment_arousal(agent)
+        # The downward mirror: a manager's felt pull to ensure her TEAM delivers,
+        # so stewarding the org weighs as much as her own deadlines and the asks
+        # landing from above — and doesn't lose every cycle to upward reporting.
+        await self._dispatch_stewardship_arousal(agent)
 
         agent.transition(AgentState.PLANNING)
 
@@ -748,16 +752,18 @@ class Fabric:
         if directive_ctx:
             context = context + "\n\n---\n\n" + directive_ctx
 
+        # For a manager, ensuring the TEAM delivers sits right below the asks
+        # from above — the downward mirror, ABOVE her own promises, so stewarding
+        # the org isn't buried under her personal deadlines or upward reporting.
+        reports_ctx = self._reports_commitment_context(agent)
+        if reports_ctx:
+            context = context + "\n\n---\n\n" + reports_ctx
+
         # The agent's own commitments — promises she's made, with their
         # deadlines and how pressing each is right now.
         commit_ctx = self._commitment_salience_context(agent)
         if commit_ctx:
             context = context + "\n\n---\n\n" + commit_ctx
-
-        # For a manager: reports whose own promises are slipping (her focus).
-        reports_ctx = self._reports_commitment_context(agent)
-        if reports_ctx:
-            context = context + "\n\n---\n\n" + reports_ctx
 
         # Things she's waiting on that are now due + silent — chase them.
         self._resolve_expectations_from_inbox(agent)
@@ -4637,6 +4643,29 @@ class Fabric:
         except Exception:
             logger.debug("commitment arousal hook failed", exc_info=True)
 
+    async def _dispatch_stewardship_arousal(self, agent: Agent) -> None:
+        """Feed a manager's team-delivery load into chemistry — the drive to
+        steward (unblock, re-scope, re-resource) that rises as the team's
+        promises slip. The downward mirror of ``_dispatch_commitment_arousal``.
+        Read-only; idempotent (the plugin raises drive/alertness to a floor,
+        never stacks). Non-managers and on-track teams produce no pressure and
+        fire nothing."""
+        try:
+            load = self._team_delivery_load(agent)
+            pressure = float(load.get("pressure", 0.0) or 0.0)
+            if pressure <= 0.0:
+                return
+            await self.plugin_manager.dispatch_hook(
+                agent.id,
+                "stewardship",
+                {
+                    "pressure": pressure,
+                    "at_risk": int(load.get("at_risk", 0)) + int(load.get("overdue", 0)),
+                },
+            )
+        except Exception:
+            logger.debug("stewardship arousal hook failed", exc_info=True)
+
     def _escalate_at_risk_commitments(self, agent: Agent) -> None:
         """For each open commitment that can't land at a normal pace (U≥1) or is
         overdue, raise it to a human — once per commitment. Also archives
@@ -4857,41 +4886,134 @@ class Fabric:
             )
         return "\n".join(lines)
 
-    def _reports_commitment_context(self, agent: Agent) -> str:
-        """For a manager: their reports' at-risk / overdue commitments, so a
-        slipping promise gets management focus rather than sliding quietly."""
+    def _team_delivery_load(self, agent: Agent) -> dict:
+        """Aggregate a manager's team-delivery picture from their reports'
+        commitment ledgers — the single source of truth for BOTH the stewardship
+        salience block and the stewardship arousal hook.
+
+        Returns ``{promised, at_risk, overdue, pressure, slipping_rows,
+        on_track_rows}`` where ``pressure`` [0,1] tracks how badly the team is
+        slipping (the worst single report's felt pressure, lifted a little for
+        each additional report that's also behind) — so it stays near zero while
+        the team is on track and climbs as real value goes at risk. The row
+        lists are pre-formatted for the salience block."""
+        empty = {
+            "promised": 0,
+            "at_risk": 0,
+            "overdue": 0,
+            "pressure": 0.0,
+            "slipping_rows": [],
+            "on_track_rows": [],
+        }
         if self.org is None:
-            return ""
+            return empty
         reports = self.org.subordinates_of(agent.id)
         if not reports:
-            return ""
+            return empty
         from datetime import UTC, datetime
 
         from cortiva.core import commitments as _cm
 
         now = datetime.now(UTC)
-        rows: list[str] = []
+        promised = at_risk = overdue = 0
+        slipping_reports = 0
+        slipping_felt: list[float] = []
+        slipping_rows: list[str] = []
+        on_track_rows: list[str] = []
         for rid in reports:
             try:
                 ra = self.get_agent(rid)
                 items = _cm.load(ra.directory)
             except Exception:
                 continue
-            for c in items:
-                if c.status != "open":
-                    continue
+            opens = [c for c in items if c.status == "open"]
+            if not opens:
+                continue
+            report_slipping = False
+            for c in opens:
+                promised += 1
+                is_od = _cm.is_overdue(c, now)
                 u = _cm.required_utilisation(c, now)
-                if u < _cm.AT_RISK_UTILISATION and not _cm.is_overdue(c, now):
-                    continue
-                state = "🔴 OVERDUE" if _cm.is_overdue(c, now) else f"🔴 at risk (U={u:.1f})"
-                rows.append(f'- **{rid}** — "{c.what}" to {c.to}, due {c.due_at}: {state}')
-        if not rows:
+                if is_od or u >= _cm.AT_RISK_UTILISATION:
+                    report_slipping = True
+                    if is_od:
+                        overdue += 1
+                        state = "🔴 OVERDUE"
+                    else:
+                        at_risk += 1
+                        state = f"🟠 at risk (U={u:.1f})"
+                    slipping_rows.append(
+                        f'- **{rid}** — "{c.what}" to {c.to}, due {c.due_at}: {state}'
+                    )
+                else:
+                    on_track_rows.append(f'- **{rid}** — "{c.what}" to {c.to}, due {c.due_at}')
+            if report_slipping:
+                slipping_reports += 1
+                slipping_felt.append(_cm.felt_pressure(opens, now))
+        # Pressure reflects the team being BEHIND, not merely busy: zero while
+        # everyone is on track (any open promise carries a hair of felt pressure,
+        # so we must gate on actual slippage), driven by the worst slipping
+        # report and lifted a little for each additional report also behind.
+        worst = max(slipping_felt, default=0.0)
+        pressure = min(1.0, worst + 0.1 * max(0, slipping_reports - 1)) if slipping_reports else 0.0
+        return {
+            "promised": promised,
+            "at_risk": at_risk,
+            "overdue": overdue,
+            "pressure": round(pressure, 3),
+            "slipping_rows": slipping_rows,
+            "on_track_rows": on_track_rows,
+        }
+
+    def _reports_commitment_context(self, agent: Agent) -> str:
+        """Top-of-mind block for a manager: ensuring their TEAM delivers value —
+        the downward mirror of ``_directive_salience_context``. Surfaces the
+        team's live promises proactively (not only once they're on fire) and
+        escalates the slipping ones with a delegate-and-track template, in the
+        same imperative register as the directives that land from above. This is
+        what stops 'ensure the team delivers' losing every cycle to upward
+        reporting — it now sits at the top of mind with the same weight."""
+        load = self._team_delivery_load(agent)
+        if load["promised"] == 0:
             return ""
-        return (
-            "## ⚠️ Your team's at-risk commitments\n"
-            "Reports of yours are behind on promises they made. This is yours "
-            "to help unblock, re-scope, or chase — don't let it slide.\n" + "\n".join(rows[:12])
-        )
+        lines = [
+            "## ⬇️ Top of mind — ensuring your team delivers",
+            "",
+            "**Your core job as a manager is your team delivering value — this "
+            "OUTRANKS polishing your own reporting upward.** A report's "
+            "undelivered promise is *your* problem to solve, not only theirs. "
+            "Don't leave a slip as a note or a nudge — **act through your "
+            "authority**: unblock it, re-scope it with the owner, chase it, or "
+            "direct the AR/resourcing lead to **re-resource** (move focus or add "
+            "a hand). Track it to delivery, then confirm the value actually "
+            "landed — never count it handled on a reply alone.",
+        ]
+        slipping = load["slipping_rows"]
+        if slipping:
+            lines.append("")
+            lines.append(
+                f"**🔴 Slipping now — {len(slipping)} at risk / overdue. Step in this cycle:**"
+            )
+            lines.extend(slipping[:12])
+            lines.append("")
+            lines.append(
+                "Decompose each into a parent task with SUB-TASKS:\n"
+                "```\n"
+                "- [ ] **[CRITICAL]** Unblock <report>'s slipping <promise>\n"
+                "  - [ ] Find what's actually blocking them (ask / check)\n"
+                "  - [ ] Unblock, re-scope, or direct AR to re-resource\n"
+                "  - [ ] Track to delivery; confirm the value actually landed\n"
+                "```"
+            )
+        on_track = load["on_track_rows"]
+        if on_track:
+            lines.append("")
+            lines.append(
+                f"**On track — {len(on_track)} promise(s) your team is carrying. "
+                "Keep them moving so these don't become the next fire:**"
+            )
+            lines.extend(on_track[:10])
+        return "\n".join(lines)
 
     # ------------------------------------------------------------------
     # Expectations — things the agent is WAITING ON from others. The mirror
@@ -6571,14 +6693,18 @@ class Fabric:
         if directive_ctx:
             context = context + "\n\n---\n\n" + directive_ctx
 
+        # Ensuring the team delivers stays top-of-mind on reassess too, right
+        # below the asks from above and above her own promises (same order as
+        # wake) — the team's delivery heat shifts cycle to cycle.
+        reports_ctx = self._reports_commitment_context(agent)
+        if reports_ctx:
+            context = context + "\n\n---\n\n" + reports_ctx
+
         # Commitments stay top-of-mind on every reassess too — their pressure
         # shifts as the clock runs down, so a reassess must see the current heat.
         commit_ctx = self._commitment_salience_context(agent)
         if commit_ctx:
             context = context + "\n\n---\n\n" + commit_ctx
-        reports_ctx = self._reports_commitment_context(agent)
-        if reports_ctx:
-            context = context + "\n\n---\n\n" + reports_ctx
         self._resolve_expectations_from_inbox(agent)
         expect_ctx = self._expectation_salience_context(agent)
         if expect_ctx:
@@ -6780,6 +6906,9 @@ class Fabric:
                 self._apply_standing_orders_to_ledger(agent)
                 await self._dispatch_commitment_arousal(agent)
                 self._escalate_at_risk_commitments(agent)
+                # A manager also feels the downward pull each heartbeat: her
+                # team's slipping delivery drives her to steward it (idempotent).
+                await self._dispatch_stewardship_arousal(agent)
                 # Expectations: resolve any that arrived, then feel the chase
                 # of those now due + silent (mild frustration, not cortisol).
                 self._resolve_expectations_from_inbox(agent)

--- a/tests/test_commitment_fabric.py
+++ b/tests/test_commitment_fabric.py
@@ -122,3 +122,119 @@ def test_resolve_expectations_from_inbox(tmp_path) -> None:
     (inbox / "m.json").write_text(json.dumps({"from": "marcus@x", "text": "here it is"}))
     _fab()._resolve_expectations_from_inbox(a)
     assert ex.load(a.directory)[0].status == "received"
+
+
+# ---------------------------------------------------------------------------
+# Delivery stewardship — the DOWNWARD mirror: a manager's felt responsibility
+# for their team actually delivering value (block + arousal hook).
+# ---------------------------------------------------------------------------
+
+
+def _report_dir(tmp_path, name):
+    d = tmp_path / name
+    d.mkdir()
+    return d
+
+
+def _mgr_fab(reports):
+    """Fabric stub where 'ceo' manages the given {rid: directory} reports."""
+    fab = Fabric.__new__(Fabric)
+    fab.org = SimpleNamespace(subordinates_of=lambda aid: list(reports) if aid == "ceo" else [])
+    fab.get_agent = lambda rid: SimpleNamespace(id=rid, directory=reports[rid])
+    return fab
+
+
+def _ceo(tmp_path):
+    d = tmp_path / "ceo"
+    d.mkdir()
+    return SimpleNamespace(id="ceo", directory=d)
+
+
+def test_team_delivery_load_empty_without_reports(tmp_path) -> None:
+    fab = Fabric.__new__(Fabric)
+    fab.org = None
+    load = fab._team_delivery_load(_agent(tmp_path))
+    assert load["promised"] == 0 and load["pressure"] == 0.0
+
+
+def test_stewardship_block_surfaces_promised_and_escalates_slipping(tmp_path) -> None:
+    now = datetime.now(UTC)
+    astrid = _report_dir(tmp_path, "astrid")
+    simone = _report_dir(tmp_path, "simone")
+    # Astrid: slipping (big effort, ~no time → U high)
+    cm.register(
+        astrid,
+        to="maren@x",
+        what="ship the launch",
+        due=(now + timedelta(hours=1)).isoformat(),
+        effort_hours=40,
+    )
+    # Simone: on track (small effort, lots of time)
+    cm.register(
+        simone,
+        to="board@x",
+        what="quarterly numbers",
+        due=(now + timedelta(days=10)).isoformat(),
+        effort_hours=2,
+    )
+    out = _mgr_fab({"astrid": astrid, "simone": simone})._reports_commitment_context(_ceo(tmp_path))
+    assert "ensuring your team delivers" in out.lower()
+    assert "OUTRANKS" in out  # imperative register, like directives
+    assert "ship the launch" in out  # the slipping one
+    assert "Slipping now" in out
+    assert "quarterly numbers" in out  # on-track one surfaced PROACTIVELY
+    assert "On track" in out
+
+
+def test_stewardship_block_empty_when_team_has_no_promises(tmp_path) -> None:
+    astrid = _report_dir(tmp_path, "astrid")
+    assert _mgr_fab({"astrid": astrid})._reports_commitment_context(_ceo(tmp_path)) == ""
+
+
+def test_stewardship_arousal_fires_when_team_slipping(tmp_path) -> None:
+    import asyncio
+
+    now = datetime.now(UTC)
+    astrid = _report_dir(tmp_path, "astrid")
+    cm.register(
+        astrid,
+        to="maren@x",
+        what="ship the launch",
+        due=(now + timedelta(hours=1)).isoformat(),
+        effort_hours=40,
+    )
+    fab = _mgr_fab({"astrid": astrid})
+    fired: dict = {}
+
+    async def _dispatch(agent_id, event_type, payload):
+        fired["event"] = event_type
+        fired["payload"] = payload
+
+    fab.plugin_manager = SimpleNamespace(dispatch_hook=_dispatch)
+    asyncio.run(fab._dispatch_stewardship_arousal(_ceo(tmp_path)))
+    assert fired.get("event") == "stewardship"
+    assert fired["payload"]["pressure"] > 0.0
+    assert fired["payload"]["at_risk"] >= 1
+
+
+def test_stewardship_arousal_silent_when_team_on_track(tmp_path) -> None:
+    import asyncio
+
+    now = datetime.now(UTC)
+    simone = _report_dir(tmp_path, "simone")
+    cm.register(
+        simone,
+        to="board@x",
+        what="quarterly numbers",
+        due=(now + timedelta(days=10)).isoformat(),
+        effort_hours=2,
+    )
+    fab = _mgr_fab({"simone": simone})
+    fired: dict = {}
+
+    async def _dispatch(agent_id, event_type, payload):
+        fired["event"] = event_type
+
+    fab.plugin_manager = SimpleNamespace(dispatch_hook=_dispatch)
+    asyncio.run(fab._dispatch_stewardship_arousal(_ceo(tmp_path)))
+    assert fired == {}  # on-track team → no pressure → nothing fired


### PR DESCRIPTION
## Summary
Managers (esp. Maren) over-index on **upward** management because the salience machinery is asymmetric: directives from above get a top-of-mind block ("outranks anything you set for yourself") **and** neurochemistry, while ensuring the team delivers had only a soft, reactive "don't let it slide" block and **no** neurochemistry. This adds the symmetric downward counterpart — the upward path is untouched. Pairs with the chemistry half in Innovology/cortiva-hq#336.

## Acceptance Criteria
- [x] `_team_delivery_load` returns `promised=0, pressure=0.0` for a non-manager / no-reports agent — verified by `test_team_delivery_load_empty_without_reports`
- [x] `_reports_commitment_context` renders a top-of-mind "⬇️ ensuring your team delivers" block that surfaces on-track promises proactively AND escalates slipping ones — verified by `test_stewardship_block_surfaces_promised_and_escalates_slipping`
- [x] The block is empty when the team holds no open promises — verified by `test_stewardship_block_empty_when_team_has_no_promises`
- [x] `_dispatch_stewardship_arousal` fires the `stewardship` hook with `pressure>0` when a report is at-risk/overdue — verified by `test_stewardship_arousal_fires_when_team_slipping`
- [x] `_dispatch_stewardship_arousal` fires nothing when the whole team is on track — verified by `test_stewardship_arousal_silent_when_team_on_track`
- [x] The stewardship block sits directly below the directive block (above own commitments) at both wake and reassess — verified by inspection of both context-assembly sites in `fabric.py`

## Agent Review Prompt
**Change summary:** Adds delivery-stewardship salience + arousal dispatch — the downward mirror of directive salience, so ensuring the team delivers weighs as much as an ask from above.
**Acceptance criteria to verify:** the six criteria above.
**Risks:** backwards-compat (reframes `_reports_commitment_context`, adds new methods; existing directive/commitment/expectation paths untouched). No security / money-path / data-integrity surface.
**Human review focus:** the pressure formula in `_team_delivery_load` (0 while on-track, rises with slippage) and the reposition of the block at both context-assembly sites.

## ADR/RFC Reference
**ADR/RFC:** N/A — behavioural mirror of the already-shipped directive-salience mechanism; no new architectural decision.

## Changes
- `_team_delivery_load()` — single source of truth aggregating reports' commitment ledgers → counts + a pressure scalar that is 0 while on-track and rises with slippage.
- `_reports_commitment_context()` reframed into the proactive top-of-mind stewardship block; repositioned below the directive block at wake + reassess.
- `_dispatch_stewardship_arousal()` — mirror of `_dispatch_commitment_arousal`; fired at wake + each heartbeat; idempotent; silent for non-managers / on-track teams.

## Test plan
- [x] 5 new tests (`test_commitment_fabric.py`): empty-without-reports, proactive+escalating block, empty-when-no-promises, arousal-fires-when-slipping, arousal-silent-on-track
- [x] Full framework suite green (90 passed); ruff check + format clean; mypy clean

## Staging Gate
**Staging run:** N/A — no money-path risk (agent prioritisation salience, not a customer money path)

## AI Delegation
**AI Delegation:** Claude (Opus) authored the salience block, aggregation, arousal dispatch, and tests against the existing directive/commitment patterns; human to verify the pressure formula and deploy path.
**Prompt owner:** @amara

## Checklist
- [x] Tests added or updated
- [x] Acceptance Criteria above are specific and testable
- [x] Agent Review Prompt completed (or AI Delegation set to N/A)
- [x] ADR/RFC reference filled
- [x] No secrets or credentials in this diff