### PR TITLE
feat(fabric): founder-brief ritual — the org head consults the owner on direction

### DIFF
--- a/src/cortiva/core/fabric.py
+++ b/src/cortiva/core/fabric.py
@@ -15,6 +15,7 @@ import logging
 import os
 import platform
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -758,6 +759,13 @@ class Fabric:
         reports_ctx = self._reports_commitment_context(agent)
         if reports_ctx:
             context = context + "\n\n---\n\n" + reports_ctx
+
+        # The org head's periodic consultation with the owner — pull the
+        # leadership's strategy/roadmap material, put it in front of the
+        # founder for feedback. Upward substance, not upward status.
+        brief_ctx = self._founder_brief_context(agent)
+        if brief_ctx:
+            context = context + "\n\n---\n\n" + brief_ctx
 
         # The agent's own commitments — promises she's made, with their
         # deadlines and how pressing each is right now.
@@ -4745,6 +4753,137 @@ class Fabric:
         except Exception:
             logger.debug("commitment arousal hook failed", exc_info=True)
 
+    # Days between founder briefs — the consultation cadence for org heads.
+    _FOUNDER_BRIEF_CADENCE_DAYS = 7.0
+
+    def _founder_addresses(self) -> set[str]:
+        """Founder email addresses from the org's email config contacts."""
+        addrs: set[str] = set()
+        try:
+            for c in self._email_meta().get("contacts") or []:
+                m = re.search(r"[\w.+-]+@[\w.-]+", str(c.get("address", "")))
+                if m:
+                    addrs.add(m.group(0).lower())
+        except Exception:
+            logger.debug("founder address resolution failed", exc_info=True)
+        return addrs
+
+    def _is_org_head(self, agent: Agent) -> bool:
+        """True for the agent at the top of the chart — has reports, and their
+        named manager is a human outside the agent set (e.g. 'human-founder')."""
+        if self.org is None or not self.org.subordinates_of(agent.id):
+            return False
+        mgr = self.org.manager_of(agent.id)
+        return mgr is None or mgr not in self.agents
+
+    def _last_founder_brief_at(self, agent: Agent) -> datetime | None:
+        """When the last real founder brief was SENT — resolved from the sent
+        record (an email to a founder address whose subject starts 'Founder
+        Brief'), cached in ``founder_briefs.json``. Planning to brief is not
+        briefing; only the sent artifact counts."""
+        from datetime import UTC, datetime
+
+        state_path = agent.directory / "founder_briefs.json"
+        last: datetime | None = None
+        try:
+            if state_path.exists():
+                s = json.loads(state_path.read_text(encoding="utf-8")).get("last_brief_at")
+                if s:
+                    last = datetime.fromisoformat(s)
+        except (ValueError, OSError):
+            last = None
+        founders = self._founder_addresses()
+        sent = agent.directory / "outbox" / "email" / "sent"
+        if founders and sent.is_dir():
+            for p in sent.glob("*.json"):
+                try:
+                    d = json.loads(p.read_text(encoding="utf-8"))
+                except (ValueError, OSError):
+                    continue
+                subject = str(d.get("subject") or "")
+                if not subject.lower().startswith("founder brief"):
+                    continue
+                recips = " ".join(str(d.get(k) or "") for k in ("to", "cc")).lower()
+                if not any(a in recips for a in founders):
+                    continue
+                try:
+                    when = datetime.fromisoformat(str(d.get("queued_at") or d.get("sent_at") or ""))
+                    if when.tzinfo is None:
+                        when = when.replace(tzinfo=UTC)
+                except (ValueError, TypeError):
+                    try:
+                        when = datetime.fromtimestamp(p.stat().st_mtime, tz=UTC)
+                    except OSError:
+                        continue
+                if last is None or when > last:
+                    last = when
+        if last is not None:
+            try:
+                state_path.write_text(
+                    json.dumps({"last_brief_at": last.isoformat()}), encoding="utf-8"
+                )
+            except OSError:
+                pass
+        return last
+
+    def _founder_brief_context(self, agent: Agent) -> str:
+        """The consultation ritual for the org head — periodically pull the
+        strategy/roadmap material their leadership has produced and put it in
+        front of the founder FOR FEEDBACK, while direction can still be steered.
+
+        Fixes the gap the sailcoach roadmap exposed: the CTO/CPO's roadmap
+        thinking never consolidated into an artifact, never reached the CEO,
+        and the CEO never thought to offer the founder a look — every channel
+        upward was reactive (replies, status, asks). Nothing in the machinery
+        modelled the OWNER as a stakeholder whose feedback should be sought on
+        direction. This block is the counterweight to the delivery-stewardship
+        one: stewardship stopped upward *status theatre*; this mandates upward
+        *consultation* — sharing substance and inviting steer, which is a
+        different act entirely. Resolves only when a 'Founder Brief' email is
+        actually sent to a founder address."""
+        if not self._is_org_head(agent):
+            return ""
+        if not self._founder_addresses():
+            return ""  # no founder contact configured — nowhere to send it
+        from datetime import UTC, datetime
+
+        last = self._last_founder_brief_at(agent)
+        now = datetime.now(UTC)
+        if last is not None:
+            days = (now - last).total_seconds() / 86400.0
+            if days < self._FOUNDER_BRIEF_CADENCE_DAYS:
+                return ""
+            opener = f"Your last founder brief was {days:.0f} days ago."
+        else:
+            opener = "You have never sent the founder a brief."
+        return "\n".join(
+            [
+                "## 🧭 Founder brief due — consult the owner on direction",
+                "",
+                f"{opener} The founder owns this company; the significant work "
+                "products shaping where it goes over the coming months — product "
+                "roadmaps, feature strategy, architecture positions — belong in "
+                "front of them **for feedback while direction can still be "
+                "steered**, not discovered after the fact. This is "
+                "CONSULTATION, not a status report: you are sharing substance "
+                "and inviting steer, not performing busyness.",
+                "",
+                "1. **PULL** — ask your leadership team what roadmap/strategy "
+                "material they have produced or are carrying in their heads. If "
+                "it exists only as fragments across plans and 1-1s, have them "
+                "consolidate it into one shareable artifact first.",
+                "2. **PUSH** — email the founder with a subject starting "
+                '"Founder Brief": include the artifacts (or where they live), '
+                "name the direction decisions currently in motion, and "
+                "explicitly invite feedback — e.g. \"here's the roadmap "
+                "Samantha & Astrid have produced; we would appreciate your "
+                'steer".',
+                "",
+                "This resolves ONLY when that email is actually sent — planning "
+                "to brief is not briefing.",
+            ]
+        )
+
     async def _dispatch_stewardship_arousal(self, agent: Agent) -> None:
         """Feed a manager's team-delivery load into chemistry — the drive to
         steward (unblock, re-scope, re-resource) that rises as the team's
@@ -6810,6 +6949,12 @@ class Fabric:
         reports_ctx = self._reports_commitment_context(agent)
         if reports_ctx:
             context = context + "\n\n---\n\n" + reports_ctx
+
+        # A due founder brief keeps confronting the org head on reassess too —
+        # it self-resolves only when the brief is actually sent.
+        brief_ctx = self._founder_brief_context(agent)
+        if brief_ctx:
+            context = context + "\n\n---\n\n" + brief_ctx
 
         # Commitments stay top-of-mind on every reassess too — their pressure
         # shifts as the clock runs down, so a reassess must see the current heat.

--- a/tests/test_commitment_fabric.py
+++ b/tests/test_commitment_fabric.py
@@ -341,3 +341,76 @@ def test_escalation_reports_overtime_honesty(tmp_path) -> None:
     caught.clear()
     fab._escalate_at_risk_commitments(b)
     assert caught and "pulled overtime first (1 coffee(s)" in caught[0]
+
+
+# ---------------------------------------------------------------------------
+# Founder-brief ritual: the org head periodically consults the OWNER on
+# direction — pull the leadership's roadmap/strategy material, push it to the
+# founder for feedback. Resolves only on a real sent "Founder Brief" email.
+# ---------------------------------------------------------------------------
+
+
+def _head_fab(founder_addr="alex@x.io", *, head=True):
+    fab = Fabric.__new__(Fabric)
+    fab.org = SimpleNamespace(
+        subordinates_of=lambda aid: ["cto", "cpo"] if aid == "ceo" else [],
+        manager_of=lambda aid: "human-founder" if aid == "ceo" else "ceo",
+    )
+    fab.agents = {"ceo": object(), "cto": object(), "cpo": object()}
+    fab._email_meta = lambda: {"contacts": [{"address": founder_addr}]} if founder_addr else {}
+    return fab
+
+
+def test_founder_brief_fires_for_org_head_never_briefed(tmp_path) -> None:
+    a = _agent(tmp_path)  # id="ceo"
+    out = _head_fab()._founder_brief_context(a)
+    assert "Founder brief due" in out
+    assert "never sent" in out
+    assert "PULL" in out and "PUSH" in out
+    assert "feedback" in out
+    assert "not a status report" in out.lower() or "CONSULTATION" in out
+
+
+def test_founder_brief_silent_for_non_head_and_no_founder(tmp_path) -> None:
+    fab = _head_fab()
+    # A mid-org manager (cto reports to ceo, an in-org agent) never sees it.
+    d = tmp_path / "cto"
+    d.mkdir()
+    cto = SimpleNamespace(id="cto", directory=d)
+    assert fab._founder_brief_context(cto) == ""
+    # No founder contact configured → nowhere to send → silent.
+    a = _agent(tmp_path)
+    assert _head_fab(founder_addr=None)._founder_brief_context(a) == ""
+
+
+def _write_sent_brief(agent_dir, *, to="alex@x.io", subject="Founder Brief — W28", when=None):
+    sent = agent_dir / "outbox" / "email" / "sent"
+    sent.mkdir(parents=True, exist_ok=True)
+    when = when or datetime.now(UTC)
+    (sent / "b.json").write_text(
+        json.dumps({"to": to, "subject": subject, "queued_at": when.isoformat()})
+    )
+
+
+def test_founder_brief_resolves_on_sent_brief_and_reopens_after_cadence(tmp_path) -> None:
+    a = _agent(tmp_path)
+    fab = _head_fab()
+    # A brief sent yesterday → quiet.
+    _write_sent_brief(a.directory, when=datetime.now(UTC) - timedelta(days=1))
+    assert fab._founder_brief_context(a) == ""
+    # …and the resolution is cached.
+    assert json.loads((a.directory / "founder_briefs.json").read_text())["last_brief_at"]
+    # A brief 8 days old → cadence elapsed → fires again with the age named.
+    _write_sent_brief(a.directory, when=datetime.now(UTC) - timedelta(days=8))
+    (a.directory / "founder_briefs.json").unlink()
+    out = fab._founder_brief_context(a)
+    assert "Founder brief due" in out
+    assert "8 days ago" in out
+
+
+def test_founder_brief_ignores_non_brief_mail_to_founder(tmp_path) -> None:
+    a = _agent(tmp_path)
+    # Ordinary founder mail (status/asks) does NOT count as a brief.
+    _write_sent_brief(a.directory, subject="Two items I need from you this week")
+    out = _head_fab()._founder_brief_context(a)
+    assert "Founder brief due" in out


### PR DESCRIPTION
## Summary
The sailcoach roadmap gap: strategy work by the CTO/CPO never consolidated, never reached the CEO, and the CEO never thought to put it in front of the founder for feedback — every upward channel was reactive (replies, status, asks). Nothing models the OWNER as a stakeholder whose steer should be sought on direction. This adds the consultation ritual: the org head periodically PULLs the leadership's roadmap/strategy material and PUSHes it to the founder explicitly inviting feedback. The counterweight to delivery-stewardship: that suppressed upward status theatre; this mandates upward substance.

## Acceptance Criteria
- [x] Block fires for the org head who has never briefed, demanding PULL (collect/consolidate leadership strategy material) + PUSH (send with feedback invitation) — verified by `test_founder_brief_fires_for_org_head_never_briefed`
- [x] Silent for non-heads and when no founder contact is configured — verified by `test_founder_brief_silent_for_non_head_and_no_founder`
- [x] Resolves only on a real sent "Founder Brief" email to a founder address; reopens after the 7-day cadence with the age named — verified by `test_founder_brief_resolves_on_sent_brief_and_reopens_after_cadence`
- [x] Ordinary founder mail (status/asks) does not count as a brief — verified by `test_founder_brief_ignores_non_brief_mail_to_founder`
- [x] Injected at wake + reassess below the stewardship block — verified by inspection of both call sites

## Agent Review Prompt
**Change summary:** Weekly founder-brief ritual for org heads: pull leadership strategy artifacts, push to the founder for feedback; artifact-gated self-resolution.
**Acceptance criteria to verify:** the five above.
**Risks:** backwards-compat (new salience block; existing paths untouched). No security / money-path / data-integrity surface.
**Human review focus:** the org-head predicate (manager outside the agent set) and the "Founder Brief" subject-prefix resolution convention.

## ADR/RFC Reference
**ADR/RFC:** N/A — behavioural salience ritual following the shipped directive-salience / stewardship / journaling-ritual mechanisms; no new architectural decision.

## Changes
- `fabric.py`: `_founder_brief_context()`, `_last_founder_brief_at()` (sent-record resolution + founder_briefs.json cache), `_founder_addresses()`, `_is_org_head()`, `_FOUNDER_BRIEF_CADENCE_DAYS=7`; wake + reassess injection; module-level `datetime` import for annotations.
- 4 new tests.

## Test plan
- [x] 20/20 `test_commitment_fabric.py` (4 new); 1662 passed across the full suite; ruff check+format clean; mypy clean. (`test_single_agent_cycle` fails on clean main locally — pre-existing, time-dependent, unrelated.)

## Staging Gate
**Staging run:** N/A — no money-path risk (agent salience ritual)

## AI Delegation
**AI Delegation:** Claude (Opus) performed the evidence RCA (email_events/inbox/repo sweep) and authored the ritual + tests; human named the missing behaviour (consult the owner on direction).
**Prompt owner:** @amara

## Checklist
- [x] Tests added or updated
- [x] Acceptance Criteria above are specific and testable
- [x] Agent Review Prompt completed (or AI Delegation set to N/A)
- [x] ADR/RFC reference filled
- [x] No secrets or credentials in this diff