### PR TITLE
fix(fabric): own your deadlines — self-set deadlines never flag a human; escalations lead with a decision

### DIFF
--- a/src/cortiva/core/commitments.py
+++ b/src/cortiva/core/commitments.py
@@ -378,6 +378,29 @@ def required_utilisation(c: Commitment, now: datetime | None = None) -> float:
     return work / rem
 
 
+def is_self_owed(c: Commitment, *, agent_id: str, first_name: str = "", email: str = "") -> bool:
+    """True when this promise is owed to the agent ITSELF — a self-set deadline
+    on self-scoped work in a self-planned day.
+
+    The distinction is load-bearing: a promise to SOMEONE ELSE that slips is
+    theirs to hear about; a deadline you set YOURSELF that slips is yours to
+    move, descope, or make — flagging it to a human ("I can't fit a 2h task
+    into 30 minutes, just wanted to flag it") transfers your planning problem
+    to someone who never owned it."""
+    to = (c.to or "").strip().lower()
+    if not to:
+        return True  # a promise to nobody is a self-plan
+    candidates = {agent_id.strip().lower()}
+    if first_name:
+        candidates.add(first_name.strip().lower())
+    if email:
+        e = email.strip().lower()
+        candidates.add(e)
+        candidates.add(e.split("@")[0])
+    to_token = re.split(r"[@<\s(]", to)[0]
+    return to in candidates or to_token in candidates
+
+
 def overtime_can_save(c: Commitment, now: datetime | None = None) -> bool:
     """True when this promise no longer fits normal working hours but IS still
     winnable by extending the day (overtime) — the band where the right

--- a/src/cortiva/core/fabric.py
+++ b/src/cortiva/core/fabric.py
@@ -4909,8 +4909,23 @@ class Fabric:
 
     def _escalate_at_risk_commitments(self, agent: Agent) -> None:
         """For each open commitment that can't land at a normal pace (U≥1) or is
-        overdue, raise it to a human — once per commitment. Also archives
-        long-overdue undelivered promises as missed (self-cleaning ledger)."""
+        overdue, act — once per commitment. Also archives long-overdue
+        undelivered promises as missed (self-cleaning ledger).
+
+        Two cases, and the difference is the whole point:
+
+        * **Self-owed** (a deadline the agent set itself, on work it scoped, in
+          a day it planned): NO human is emailed. "I can't fit a 2h task into
+          30 minutes, just wanted to flag it" arriving 30 minutes before a
+          self-set deadline transfers the agent's planning failure to someone
+          who never owned it. The decision stays with the owner — reschedule
+          openly (tracked as an owner-reschedule), descope, or make it with
+          overtime; the salience block confronts them every cycle.
+        * **Owed to someone else**: the counterparty deserves to hear — but as
+          a DECISION, not a flag. The escalation leads with the agent's own
+          committed proposal (a realistic new date at normal pace), states the
+          honest reason, and carries the overtime record. Actionable or silent.
+        """
         from cortiva.core import commitments as _cm
 
         items = _cm.load(agent.directory)
@@ -4918,14 +4933,41 @@ class Fabric:
             return
         before = json.dumps([c.to_dict() for c in items], sort_keys=True)
         _cm.prune(items)
-        from datetime import UTC, datetime
+        from datetime import UTC, datetime, timedelta
 
         now = datetime.now(UTC)
+        # Who this agent IS, for the self-owed test (best-effort).
+        first_name = email = ""
+        try:
+            for card in self._load_directory_cards():
+                if card.get("id") == agent.id:
+                    first_name = str(card.get("first") or card.get("name") or "")
+                    email = str(card.get("email") or "")
+                    break
+        except Exception:
+            pass
         for c in items:
             if c.status != "open" or c.escalated_at:
                 continue
             u = _cm.required_utilisation(c, now)
             if u < _cm.AT_RISK_UTILISATION and not _cm.is_overdue(c, now):
+                continue
+            if _cm.is_self_owed(c, agent_id=agent.id, first_name=first_name, email=email):
+                # Your deadline, your call — no flag mail. Stamp escalated_at so
+                # this fires exactly once; the commitment salience block keeps
+                # demanding the owner-decision until it's rescheduled, descoped,
+                # delivered, or archived as missed.
+                c.escalated_at = now.isoformat()
+                self._emit(
+                    "commitment.self_deadline_at_risk",
+                    agent_id=agent.id,
+                    what=c.what[:80],
+                )
+                logger.info(
+                    "Self-set deadline at risk for %s (%r) — owner decision, no escalation mail",
+                    agent.id,
+                    c.what[:60],
+                )
                 continue
             worked = c.effort_hours * _cm.progress_of(c)
             # Honesty: say whether the agent used its own overtime lever before
@@ -4937,12 +4979,21 @@ class Fabric:
                 if coffees
                 else " No overtime was taken before this escalation."
             )
+            # Lead with a committed default proposal, not a shrug: the date this
+            # actually lands at a sustainable normal pace. The recipient accepts
+            # by silence or pushes back — either way it's actionable.
+            work_left = _cm.work_remaining_hours(c)
+            proposal = (now + timedelta(hours=work_left / _cm.NORMAL_PACE_UTILISATION)).strftime(
+                "%A %Y-%m-%d %H:%M UTC"
+            )
             esc = (
-                f"A commitment I made is at risk and I can't land it at a normal "
-                f'pace. "{c.what}" — promised to {c.to}, due {c.due_at}. About '
-                f"{worked:.1f}h of ~{c.effort_hours:.1f}h is done and the time "
-                f"left can't absorb the rest. I need help, a re-scope, or a new "
-                f"deadline." + overtime_note
+                f'My commitment to you is not going to land on time: "{c.what}" '
+                f"— due {c.due_at}, about {worked:.1f}h of ~{c.effort_hours:.1f}h "
+                f"done. My decision: I am rescheduling delivery to {proposal} "
+                f"and will deliver by then — push back now if that date doesn't "
+                f"work and I'll re-plan around your constraint. The honest "
+                f"reason it slipped: [say it plainly — a planning miss is a "
+                f"planning miss]." + overtime_note
             )
             try:
                 self._route_escalation(agent, c.what, esc)
@@ -5074,6 +5125,16 @@ class Fabric:
 
         now = datetime.now(UTC)
         opens.sort(key=lambda c: _cm.required_utilisation(c, now), reverse=True)
+        # Who this agent IS, for the self-owed test (best-effort).
+        _first = _email = ""
+        try:
+            for card in self._load_directory_cards():
+                if card.get("id") == agent.id:
+                    _first = str(card.get("first") or card.get("name") or "")
+                    _email = str(card.get("email") or "")
+                    break
+        except Exception:
+            pass
         lines = [
             "## ⏳ Your commitments — promises you've made, tracked to delivery\n",
             f"**Right now it is {now.strftime('%A %Y-%m-%d %H:%M')} UTC.** Reason "
@@ -5085,8 +5146,13 @@ class Fabric:
             "remaining, the more it weighs on you; that pressure is real and "
             "yours to discharge. Work the most pressing first. Log progress as "
             "you go so a half-done job doesn't read as a crisis. If one truly "
-            "can't land, re-scope or escalate it NOW — never let it slip "
-            "silently. Need to push through tonight? `drink_coffee`. And "
+            "can't land: a deadline YOU set on YOUR OWN plan is yours to move — "
+            "reschedule it (`update_commitment` with a new due date), descope "
+            "it, or make it with overtime; **never email anyone a 'just "
+            "flagging' about your own planning — moving your own deadline is "
+            "your job, not theirs.** Only a promise to SOMEONE ELSE warrants "
+            "telling them — and then lead with your new committed date, not a "
+            "flag. Need to push through tonight? `drink_coffee`. And "
             "register any NEW promise you make this cycle with "
             "`register_commitment` so it joins this list.\n",
             "**Test before you trust.** Before you believe a commitment is "
@@ -5129,10 +5195,25 @@ class Fabric:
                         f"  \n  ✅ a real artifact exists ({desc}) — if this "
                         "commitment is done, mark it delivered to close it."
                     )
+            # A failing deadline the agent set ITSELF gets the mirror, not a
+            # megaphone: the decision is theirs alone, and flagging it upward
+            # ("I can't fit a 2h task into 30 minutes, just wanted to flag it")
+            # is explicitly not an option.
+            own = ""
+            if (u >= _cm.AT_RISK_UTILISATION or _cm.is_overdue(c, now)) and _cm.is_self_owed(
+                c, agent_id=agent.id, first_name=_first, email=_email
+            ):
+                own = (
+                    "  \n  🪞 **This deadline is YOURS — you scoped it, you "
+                    "scheduled it. Decide NOW: reschedule it to a date you'll "
+                    "actually hit (`update_commitment`, openly — it's tracked), "
+                    "descope it, or make it with overtime. Do NOT email anyone "
+                    "a flag about it — nobody else owns your plan.**"
+                )
             lines.append(
                 f"- **{c.what}** — to {c.to}; due {c.due_at} "
                 f"({_human_remaining(rem_h)}); {prog * 100:.0f}% done of "
-                f"~{c.effort_hours:.1f}h — {heat}  \n  id `{c.id[:8]}`{reality}"
+                f"~{c.effort_hours:.1f}h — {heat}  \n  id `{c.id[:8]}`{reality}{own}"
             )
         return "\n".join(lines)
 

--- a/tests/test_commitment_fabric.py
+++ b/tests/test_commitment_fabric.py
@@ -414,3 +414,103 @@ def test_founder_brief_ignores_non_brief_mail_to_founder(tmp_path) -> None:
     _write_sent_brief(a.directory, subject="Two items I need from you this week")
     out = _head_fab()._founder_brief_context(a)
     assert "Founder brief due" in out
+
+
+# ---------------------------------------------------------------------------
+# Own your deadlines: a self-set deadline that slips is the OWNER's decision
+# (reschedule/descope/overtime) — never a "just flagging it" mail to a human.
+# A promise to someone else escalates as a DECISION with a committed new date.
+# ---------------------------------------------------------------------------
+
+
+def test_is_self_owed_detection() -> None:
+    def mk(to):
+        return cm.Commitment(id="x", to=to, what="w", due_at="", effort_hours=1)
+
+    kw = {"agent_id": "ceo", "first_name": "Maren", "email": "maren@workforce.x"}
+    assert cm.is_self_owed(mk("Maren"), **kw)
+    assert cm.is_self_owed(mk("maren@workforce.x"), **kw)
+    assert cm.is_self_owed(mk("ceo"), **kw)
+    assert cm.is_self_owed(mk(""), **kw)  # promise to nobody = self-plan
+    assert not cm.is_self_owed(mk("alex@px.io"), **kw)
+    assert not cm.is_self_owed(mk("Samantha"), **kw)
+
+
+def _esc_fab(cards):
+    fab = _fab()
+    fab._load_directory_cards = lambda: cards
+    fab._recent_coffees = lambda agent, hours: 0
+    fab._emit = lambda *a, **k: None
+    return fab
+
+
+def test_self_set_deadline_never_emails_a_human(tmp_path) -> None:
+    a = _agent(tmp_path)
+    now = datetime.now(UTC)
+    cm.register(
+        a.directory,
+        to="Maren",
+        what="my own planning item",
+        due=(now + timedelta(hours=1)).isoformat(),
+        effort_hours=40,
+    )
+    fab = _esc_fab([{"id": "ceo", "first": "Maren", "email": "maren@workforce.x"}])
+    sent: list = []
+    fab._route_escalation = lambda agent, desc, esc: sent.append(esc)
+    fab._escalate_at_risk_commitments(a)
+    assert sent == []  # no flag mail, ever
+    # …and it doesn't re-fire every heartbeat: escalated_at is stamped.
+    items = cm.load(a.directory)
+    assert items[0].escalated_at
+
+
+def test_other_owed_escalation_is_a_decision_not_a_flag(tmp_path) -> None:
+    a = _agent(tmp_path)
+    now = datetime.now(UTC)
+    cm.register(
+        a.directory,
+        to="alex@px.io",
+        what="board pack",
+        due=(now + timedelta(hours=1)).isoformat(),
+        effort_hours=40,
+    )
+    fab = _esc_fab([{"id": "ceo", "first": "Maren", "email": "maren@workforce.x"}])
+    sent: list = []
+    fab._route_escalation = lambda agent, desc, esc: sent.append(esc)
+    fab._escalate_at_risk_commitments(a)
+    assert len(sent) == 1
+    esc = sent[0]
+    assert "My decision: I am rescheduling delivery to" in esc
+    assert "push back now" in esc  # actionable, recipient can veto
+    assert "honest reason" in esc.lower()
+    assert "I need help" not in esc  # the old shrug is gone
+    assert "No overtime was taken" in esc  # honesty line preserved
+
+
+def test_salience_mirror_for_failing_self_deadline(tmp_path) -> None:
+    a = _agent(tmp_path)
+    now = datetime.now(UTC)
+    cm.register(
+        a.directory,
+        to="Maren",
+        what="my own planning item",
+        due=(now + timedelta(hours=1)).isoformat(),
+        effort_hours=40,
+    )
+    fab = _esc_fab([{"id": "ceo", "first": "Maren", "email": "maren@workforce.x"}])
+    out = fab._commitment_salience_context(a)
+    assert "This deadline is YOURS" in out
+    assert "Do NOT email anyone a flag" in out
+    # An on-track self item gets no mirror.
+    a2_dir = tmp_path / "cfo"
+    a2_dir.mkdir()
+    a2 = SimpleNamespace(id="cfo", directory=a2_dir)
+    cm.register(
+        a2_dir,
+        to="Simone",
+        what="easy",
+        due=(now + timedelta(days=10)).isoformat(),
+        effort_hours=1,
+    )
+    fab2 = _esc_fab([{"id": "cfo", "first": "Simone", "email": "simone@workforce.x"}])
+    assert "This deadline is YOURS" not in fab2._commitment_salience_context(a2)


### PR DESCRIPTION
## Summary
Founder receives "I can't fit a 2hr task into 30 minutes, just wanted to flag it" mails — 30 minutes before a deadline the agent set itself, on work it scoped, in a day it planned. RCA: the U≥1 auto-escalation mailed a human for EVERY at-risk commitment including entirely self-authored ones, with a template asking the recipient for "a re-scope or a new deadline" the agent had full authority to grant itself; U≥1 for a 2h task fires exactly 2h before the wire → the last-minute flag.

## Acceptance Criteria
- [x] `is_self_owed()` detects promises owed to the agent itself by name, email, id, or empty counterparty — verified by `test_is_self_owed_detection`
- [x] A failing self-owed commitment NEVER emails a human, and fires exactly once (escalated_at stamped) — verified by `test_self_set_deadline_never_emails_a_human`
- [x] An other-owed escalation leads with a committed default proposal ("I am rescheduling delivery to <realistic date> — push back now"), demands the honest reason, keeps the overtime record, and drops the old "I need help" shrug — verified by `test_other_owed_escalation_is_a_decision_not_a_flag`
- [x] The salience block shows the 🪞 ownership demand only on failing self-deadlines — verified by `test_salience_mirror_for_failing_self_deadline`
- [x] Existing escalation/throttle/commitment behaviours preserved — 146 green across the five related suites

## Agent Review Prompt
**Change summary:** Self-owed at-risk commitments become an owner decision (salience mirror, no mail); other-owed escalations become decision-shaped with a computed default new date.
**Acceptance criteria to verify:** the five above.
**Risks:** backwards-compat (escalation text changes; self-owed path no longer mails — intended). No security / money-path surface.
**Human review focus:** the `is_self_owed` matching breadth (name/localpart tokens) and the normal-pace default-proposal computation.

## ADR/RFC Reference
**ADR/RFC:** N/A — behavioural fix in the shipped commitments-escalation mechanism; no architectural decision.

## Changes
- `commitments.is_self_owed()`
- `_escalate_at_risk_commitments`: self-owed → no mail + once-only stamp + event; other-owed → decision template with committed proposal date + honest-reason demand + overtime record
- `_commitment_salience_context`: ownership split in the intro; 🪞 mirror on failing self-deadlines

## Test plan
- [x] 24/24 `test_commitment_fabric.py` (4 new); 146 across commitment/fabric/throttle/escalation suites; ruff+format+mypy clean

## Staging Gate
**Staging run:** N/A — no money-path risk (escalation behaviour)

## AI Delegation
**AI Delegation:** Claude (Opus) performed the RCA (routing + ledger + template trace) and authored the fix + tests; human named the management principle (move it, plan better, or have a real reason — never dump it upward).
**Prompt owner:** @amara

## Checklist
- [x] Tests added or updated
- [x] Acceptance Criteria above are specific and testable
- [x] Agent Review Prompt completed (or AI Delegation set to N/A)
- [x] ADR/RFC reference filled
- [x] No secrets or credentials in this diff