### PR TITLE
fix(fabric): silent reschedules — no commitment auto-mail to anyone, ever

### DIFF
--- a/src/cortiva/core/fabric.py
+++ b/src/cortiva/core/fabric.py
@@ -4908,23 +4908,26 @@ class Fabric:
             logger.debug("stewardship arousal hook failed", exc_info=True)
 
     def _escalate_at_risk_commitments(self, agent: Agent) -> None:
-        """For each open commitment that can't land at a normal pace (U≥1) or is
-        overdue, act — once per commitment. Also archives long-overdue
+        """Reckon each open commitment that can't land at a normal pace (U≥1)
+        or is overdue — once per commitment. Also archives long-overdue
         undelivered promises as missed (self-cleaning ledger).
 
-        Two cases, and the difference is the whole point:
+        NO ONE IS AUTO-MAILED. Founder, twice: a last-minute "just wanted to
+        flag it" about a self-set deadline transfers the agent's planning
+        failure to someone who never owned it — and "I do not need to know that
+        they chose to extend their deadline" killed even the courtesy
+        notification. The machine's job is to make the slip FELT and TRACKED,
+        not to broadcast it:
 
-        * **Self-owed** (a deadline the agent set itself, on work it scoped, in
-          a day it planned): NO human is emailed. "I can't fit a 2h task into
-          30 minutes, just wanted to flag it" arriving 30 minutes before a
-          self-set deadline transfers the agent's planning failure to someone
-          who never owned it. The decision stays with the owner — reschedule
-          openly (tracked as an owner-reschedule), descope, or make it with
-          overtime; the salience block confronts them every cycle.
-        * **Owed to someone else**: the counterparty deserves to hear — but as
-          a DECISION, not a flag. The escalation leads with the agent's own
-          committed proposal (a realistic new date at normal pace), states the
-          honest reason, and carries the overtime record. Actionable or silent.
+        * the 🪞 mirror in the commitment salience block demands the owner
+          decision every cycle — reschedule (tracked as an owner-reschedule,
+          the scar to watch), descope, or make it with overtime;
+        * the manager sees slippage through the stewardship rollup — the
+          surveillance channel that actually owns the problem;
+        * the ONLY reschedule that warrants contacting the counterparty is one
+          where THEY set the date — a genuine renegotiation, which is the
+          agent's own reasoned email guided by the mirror, never this mailer;
+        * delivery (or an honest miss in the ledger) is the record.
         """
         from cortiva.core import commitments as _cm
 
@@ -4933,73 +4936,28 @@ class Fabric:
             return
         before = json.dumps([c.to_dict() for c in items], sort_keys=True)
         _cm.prune(items)
-        from datetime import UTC, datetime, timedelta
+        from datetime import UTC, datetime
 
         now = datetime.now(UTC)
-        # Who this agent IS, for the self-owed test (best-effort).
-        first_name = email = ""
-        try:
-            for card in self._load_directory_cards():
-                if card.get("id") == agent.id:
-                    first_name = str(card.get("first") or card.get("name") or "")
-                    email = str(card.get("email") or "")
-                    break
-        except Exception:
-            pass
         for c in items:
             if c.status != "open" or c.escalated_at:
                 continue
             u = _cm.required_utilisation(c, now)
             if u < _cm.AT_RISK_UTILISATION and not _cm.is_overdue(c, now):
                 continue
-            if _cm.is_self_owed(c, agent_id=agent.id, first_name=first_name, email=email):
-                # Your deadline, your call — no flag mail. Stamp escalated_at so
-                # this fires exactly once; the commitment salience block keeps
-                # demanding the owner-decision until it's rescheduled, descoped,
-                # delivered, or archived as missed.
-                c.escalated_at = now.isoformat()
-                self._emit(
-                    "commitment.self_deadline_at_risk",
-                    agent_id=agent.id,
-                    what=c.what[:80],
-                )
-                logger.info(
-                    "Self-set deadline at risk for %s (%r) — owner decision, no escalation mail",
-                    agent.id,
-                    c.what[:60],
-                )
-                continue
-            worked = c.effort_hours * _cm.progress_of(c)
-            # Honesty: say whether the agent used its own overtime lever before
-            # this landed on a human — a manager reading "no overtime taken"
-            # can push back on the complaint instead of absorbing it.
-            coffees = self._recent_coffees(agent, hours=24.0)
-            overtime_note = (
-                f" I pulled overtime first ({coffees} coffee(s) in the last 24h)."
-                if coffees
-                else " No overtime was taken before this escalation."
+            # Stamp once so this never re-fires; the salience mirror carries
+            # the confrontation from here.
+            c.escalated_at = now.isoformat()
+            self._emit(
+                "commitment.deadline_at_risk",
+                agent_id=agent.id,
+                what=c.what[:80],
             )
-            # Lead with a committed default proposal, not a shrug: the date this
-            # actually lands at a sustainable normal pace. The recipient accepts
-            # by silence or pushes back — either way it's actionable.
-            work_left = _cm.work_remaining_hours(c)
-            proposal = (now + timedelta(hours=work_left / _cm.NORMAL_PACE_UTILISATION)).strftime(
-                "%A %Y-%m-%d %H:%M UTC"
+            logger.info(
+                "Commitment at risk for %s (%r) — owner decision via salience, no auto-mail",
+                agent.id,
+                c.what[:60],
             )
-            esc = (
-                f'My commitment to you is not going to land on time: "{c.what}" '
-                f"— due {c.due_at}, about {worked:.1f}h of ~{c.effort_hours:.1f}h "
-                f"done. My decision: I am rescheduling delivery to {proposal} "
-                f"and will deliver by then — push back now if that date doesn't "
-                f"work and I'll re-plan around your constraint. The honest "
-                f"reason it slipped: [say it plainly — a planning miss is a "
-                f"planning miss]." + overtime_note
-            )
-            try:
-                self._route_escalation(agent, c.what, esc)
-                c.escalated_at = now.isoformat()
-            except Exception:
-                logger.exception("commitment escalation failed for %s", agent.id)
         after = json.dumps([c.to_dict() for c in items], sort_keys=True)
         if after != before:
             _cm.save(agent.directory, items)
@@ -5146,13 +5104,15 @@ class Fabric:
             "remaining, the more it weighs on you; that pressure is real and "
             "yours to discharge. Work the most pressing first. Log progress as "
             "you go so a half-done job doesn't read as a crisis. If one truly "
-            "can't land: a deadline YOU set on YOUR OWN plan is yours to move — "
+            "can't land: a deadline YOU chose is yours to move — "
             "reschedule it (`update_commitment` with a new due date), descope "
-            "it, or make it with overtime; **never email anyone a 'just "
-            "flagging' about your own planning — moving your own deadline is "
-            "your job, not theirs.** Only a promise to SOMEONE ELSE warrants "
-            "telling them — and then lead with your new committed date, not a "
-            "flag. Need to push through tonight? `drink_coffee`. And "
+            "it, or make it with overtime, **silently: never email anyone a "
+            "'just flagging' OR a courtesy 'I'm extending my deadline' note "
+            "— nobody needs to know you moved a date you set; they'll see "
+            "the delivery.** The ONLY slip that warrants an email is one "
+            "where the COUNTERPARTY set the date — then renegotiate "
+            "properly: your new committed date plus the honest reason. "
+            "Need to push through tonight? `drink_coffee`. And "
             "register any NEW promise you make this cycle with "
             "`register_commitment` so it joins this list.\n",
             "**Test before you trust.** Before you believe a commitment is "
@@ -5195,21 +5155,35 @@ class Fabric:
                         f"  \n  ✅ a real artifact exists ({desc}) — if this "
                         "commitment is done, mark it delivered to close it."
                     )
-            # A failing deadline the agent set ITSELF gets the mirror, not a
-            # megaphone: the decision is theirs alone, and flagging it upward
-            # ("I can't fit a 2h task into 30 minutes, just wanted to flag it")
-            # is explicitly not an option.
+            # A failing deadline gets the mirror, not a megaphone: the decision
+            # is the agent's alone. Flagging it upward ("I can't fit a 2h task
+            # into 30 minutes, just wanted to flag it") is not an option, and
+            # neither is a courtesy note about a self-administered date move —
+            # founder: "I do not need to know that they chose to extend their
+            # deadline."
             own = ""
-            if (u >= _cm.AT_RISK_UTILISATION or _cm.is_overdue(c, now)) and _cm.is_self_owed(
-                c, agent_id=agent.id, first_name=_first, email=_email
-            ):
-                own = (
-                    "  \n  🪞 **This deadline is YOURS — you scoped it, you "
-                    "scheduled it. Decide NOW: reschedule it to a date you'll "
-                    "actually hit (`update_commitment`, openly — it's tracked), "
-                    "descope it, or make it with overtime. Do NOT email anyone "
-                    "a flag about it — nobody else owns your plan.**"
-                )
+            if u >= _cm.AT_RISK_UTILISATION or _cm.is_overdue(c, now):
+                if _cm.is_self_owed(c, agent_id=agent.id, first_name=_first, email=_email):
+                    own = (
+                        "  \n  🪞 **This deadline is YOURS — you scoped it, you "
+                        "scheduled it. Decide NOW: reschedule it to a date you'll "
+                        "actually hit (`update_commitment`, openly — it's tracked), "
+                        "descope it, or make it with overtime. Do NOT email anyone "
+                        "a flag about it — nobody else owns your plan.**"
+                    )
+                else:
+                    own = (
+                        "  \n  🪞 **This won't land on time. Decide NOW, "
+                        "silently: if YOU chose this date, move it "
+                        "(`update_commitment` to a date you'll actually hit — "
+                        "tracked, no announcement; they'll see the delivery) "
+                        "or make it with overtime. Do NOT send a flag or a "
+                        "courtesy 'rescheduling' note — nobody needs to know "
+                        "you moved your own deadline. ONLY if the counterparty "
+                        "set this date themselves does an email make sense — a "
+                        "real renegotiation carrying your new committed date "
+                        "and the honest reason, nothing less.**"
+                    )
             lines.append(
                 f"- **{c.what}** — to {c.to}; due {c.due_at} "
                 f"({_human_remaining(rem_h)}); {prog * 100:.0f}% done of "

--- a/tests/test_commitment_fabric.py
+++ b/tests/test_commitment_fabric.py
@@ -68,6 +68,8 @@ def test_expectation_salience_only_when_due_and_silent(tmp_path) -> None:
 
 
 def test_escalates_at_risk_once_then_idempotent(tmp_path) -> None:
+    """At-risk reckoning stamps escalated_at exactly once and mails NOBODY
+    (the mirror + stewardship rollup carry it; no auto-mail exists)."""
     a = _agent(tmp_path)
     now = datetime.now(UTC)
     cm.register(
@@ -81,11 +83,12 @@ def test_escalates_at_risk_once_then_idempotent(tmp_path) -> None:
     fab = _fab()
     calls: list = []
     fab._route_escalation = lambda agent, desc, esc: calls.append((desc, esc))
+    fab._emit = lambda *a, **k: None
     fab._escalate_at_risk_commitments(a)
-    assert len(calls) == 1  # overdue + work owed → escalated
-    assert cm.load(a.directory)[0].escalated_at  # marked
+    assert calls == []  # no auto-mail, ever
+    assert cm.load(a.directory)[0].escalated_at  # reckoned once
     fab._escalate_at_risk_commitments(a)
-    assert len(calls) == 1  # idempotent — not re-escalated
+    assert calls == []  # and stays silent
 
 
 def test_withdrawn_and_delivered_never_escalate(tmp_path) -> None:
@@ -307,42 +310,6 @@ def test_overtime_block_suppressed_while_caffeinated(tmp_path) -> None:
     assert _fab()._overtime_decision_context(a) == ""
 
 
-def test_escalation_reports_overtime_honesty(tmp_path) -> None:
-    a = _agent(tmp_path)
-    now = datetime.now(UTC)
-    cm.register(
-        a.directory,
-        to="maren@x",
-        what="doomed",
-        due=(now + timedelta(hours=1)).isoformat(),
-        effort_hours=40,
-    )
-    fab = _fab()
-    caught: list[str] = []
-    fab._route_escalation = lambda agent, desc, esc: caught.append(esc)
-
-    # No coffee taken → the escalation says so.
-    fab._escalate_at_risk_commitments(a)
-    assert caught and "No overtime was taken" in caught[0]
-
-    # Second agent DID pull overtime → the escalation credits it.
-    b_dir = tmp_path / "cfo"
-    b_dir.mkdir()
-    b = SimpleNamespace(id="cfo", directory=b_dir)
-    cm.register(
-        b_dir,
-        to="maren@x",
-        what="doomed too",
-        due=(now + timedelta(hours=1)).isoformat(),
-        effort_hours=40,
-    )
-    (b_dir / "today").mkdir()
-    (b_dir / "today" / "coffee.json").write_text(json.dumps([datetime.now(UTC).isoformat()]))
-    caught.clear()
-    fab._escalate_at_risk_commitments(b)
-    assert caught and "pulled overtime first (1 coffee(s)" in caught[0]
-
-
 # ---------------------------------------------------------------------------
 # Founder-brief ritual: the org head periodically consults the OWNER on
 # direction — pull the leadership's roadmap/strategy material, push it to the
@@ -464,7 +431,10 @@ def test_self_set_deadline_never_emails_a_human(tmp_path) -> None:
     assert items[0].escalated_at
 
 
-def test_other_owed_escalation_is_a_decision_not_a_flag(tmp_path) -> None:
+def test_no_auto_mail_for_anyone_and_fires_once(tmp_path) -> None:
+    """Founder: "I do not need to know that they chose to extend their
+    deadline." NO commitment auto-mail — self- OR other-owed. The mirror and
+    the manager's stewardship rollup carry it instead."""
     a = _agent(tmp_path)
     now = datetime.now(UTC)
     cm.register(
@@ -478,13 +448,12 @@ def test_other_owed_escalation_is_a_decision_not_a_flag(tmp_path) -> None:
     sent: list = []
     fab._route_escalation = lambda agent, desc, esc: sent.append(esc)
     fab._escalate_at_risk_commitments(a)
-    assert len(sent) == 1
-    esc = sent[0]
-    assert "My decision: I am rescheduling delivery to" in esc
-    assert "push back now" in esc  # actionable, recipient can veto
-    assert "honest reason" in esc.lower()
-    assert "I need help" not in esc  # the old shrug is gone
-    assert "No overtime was taken" in esc  # honesty line preserved
+    assert sent == []  # nobody is auto-mailed, whoever it's owed to
+    items = cm.load(a.directory)
+    assert items[0].escalated_at  # stamped once — never re-fires
+    sent.clear()
+    fab._escalate_at_risk_commitments(a)
+    assert sent == []
 
 
 def test_salience_mirror_for_failing_self_deadline(tmp_path) -> None:
@@ -514,3 +483,22 @@ def test_salience_mirror_for_failing_self_deadline(tmp_path) -> None:
     )
     fab2 = _esc_fab([{"id": "cfo", "first": "Simone", "email": "simone@workforce.x"}])
     assert "This deadline is YOURS" not in fab2._commitment_salience_context(a2)
+
+
+def test_salience_mirror_for_failing_other_owed_deadline(tmp_path) -> None:
+    """Other-owed failing deadlines get the silent-reschedule mirror: move it
+    without an announcement; only a counterparty-set date warrants an email."""
+    a = _agent(tmp_path)
+    now = datetime.now(UTC)
+    cm.register(
+        a.directory,
+        to="alex@px.io",
+        what="board pack",
+        due=(now + timedelta(hours=1)).isoformat(),
+        effort_hours=40,
+    )
+    fab = _esc_fab([{"id": "ceo", "first": "Maren", "email": "maren@workforce.x"}])
+    out = fab._commitment_salience_context(a)
+    assert "Decide NOW, silently" in out
+    assert "nobody needs to know you moved your own deadline" in out
+    assert "ONLY if the counterparty set this date" in out


### PR DESCRIPTION
## Summary
Founder on #108's decision-shaped reschedule notification: "I do not need to know that they chose to extend their deadline." The commitment auto-mailer is removed entirely: a slipping deadline is made felt (🪞 mirror, every cycle) and tracked (owner-reschedule scar, stewardship rollup to the manager, missed-archival) — never broadcast. The only slip that warrants an email is one where the counterparty set the date, and that renegotiation is the agent's own reasoned mail guided by the mirror, not a mailer.

## Acceptance Criteria
- [x] At-risk/overdue commitments mail NOBODY, regardless of who they're owed to, and reckon exactly once (escalated_at stamped) — verified by `test_no_auto_mail_for_anyone_and_fires_once` and the rewritten `test_escalates_at_risk_once_then_idempotent`
- [x] Self-owed failing deadlines keep the ownership mirror (reschedule/descope/overtime, no flag) — verified by `test_salience_mirror_for_failing_self_deadline`
- [x] Other-owed failing deadlines get the silent-reschedule mirror (move a date you chose without announcement; only a counterparty-set date warrants an email) — verified by `test_salience_mirror_for_failing_other_owed_deadline`
- [x] Withdrawn/delivered never reckon; missed-archival unchanged — pre-existing tests green

## Agent Review Prompt
**Change summary:** Remove the commitment escalation auto-mail; extend the salience mirror to both ownership cases with silent-reschedule guidance.
**Acceptance criteria to verify:** the four above.
**Risks:** behaviour change by design — slippage visibility now flows via the stewardship rollup and the ledger, not email. No security / money-path surface.
**Human review focus:** that manager visibility via `_reports_commitment_context` is a sufficient replacement channel for the removed mail.

## ADR/RFC Reference
**ADR/RFC:** N/A — behavioural fix refining #108 per founder direction; no architectural decision.

## Changes
- `_escalate_at_risk_commitments`: stamp + `commitment.deadline_at_risk` event only; no `_route_escalation` call.
- `_commitment_salience_context`: mirror for both ownership cases; intro teaches silent-reschedule + counterparty-set-date exception.
- Tests updated to the silent contract.

## Test plan
- [x] 24/24 `test_commitment_fabric.py`; 146 across the five related suites; ruff+format+mypy clean

## Staging Gate
**Staging run:** N/A — no money-path risk (escalation behaviour)

## AI Delegation
**AI Delegation:** Claude (Opus) implemented the founder's direct instruction ("I do not need to know that they chose to extend their deadline") over the #108 mechanism.
**Prompt owner:** @amara

## Checklist
- [x] Tests added or updated
- [x] Acceptance Criteria above are specific and testable
- [x] Agent Review Prompt completed (or AI Delegation set to N/A)
- [x] ADR/RFC reference filled
- [x] No secrets or credentials in this diff